### PR TITLE
Address Example Changes in UI

### DIFF
--- a/src/qt/sendcoinsdialog.cpp
+++ b/src/qt/sendcoinsdialog.cpp
@@ -37,7 +37,7 @@ SendCoinsDialog::SendCoinsDialog(QWidget *parent) :
 
 #if QT_VERSION >= 0x040700
     /* Do not move this to the XML file, Qt before 4.7 will choke on it */
-    ui->lineEditCoinControlChange->setPlaceholderText(tr("Enter a wyvern address (e.g. wyvernNpBmRUEiP2Po1K8km2GXcFfwYh)"));
+    ui->lineEditCoinControlChange->setPlaceholderText(tr("Enter a wyvern address (e.g. WyvernNpBmRUEiP2Po1K8km2GXcFfwYh)"));
 #endif
 
     addEntry();

--- a/src/qt/sendcoinsentry.cpp
+++ b/src/qt/sendcoinsentry.cpp
@@ -23,7 +23,7 @@ SendCoinsEntry::SendCoinsEntry(QWidget *parent) :
 #if QT_VERSION >= 0x040700
     /* Do not move this to the XML file, Qt before 4.7 will choke on it */
     ui->addAsLabel->setPlaceholderText(tr("Enter a label for this address to add it to your address book"));
-    ui->payTo->setPlaceholderText(tr("Enter a wyvern address (e.g. iUuWwFn7HKcHeARezeBp5fx8Yer18hyNEN)"));
+    ui->payTo->setPlaceholderText(tr("Enter a wyvern address (e.g. WUuWwFn7HKcHeARezeBp5fx8Yer18hyNEN)"));
 #endif
     setFocusPolicy(Qt::TabFocus);
     setFocusProxy(ui->payTo);


### PR DESCRIPTION
Changes the display of the addresses in the Send Coins Dialog in the QT app, making the address examples mirror the correct formatting of the Wyvern address (Capitol W at the beginning)